### PR TITLE
Remove heap dump addon files as well

### DIFF
--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -107,7 +107,7 @@ func CleanUp(fs afero.Fs, cfg Config) ([]string, error) {
 
 		deletedFiles = append(deletedFiles, path)
 
-		// SAP JVM also creates .addon files that should be removed as well
+		// SAP JVM also creates .addons files that should be removed as well
 		addonPath := path[0:len(path)-len(".hprof")] + ".addons"
 		addonFile, err := fs.Stat(addonPath)
 		if !os.IsNotExist(err) && addonFile.Mode().isRegular() {

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -108,7 +108,7 @@ func CleanUp(fs afero.Fs, cfg Config) ([]string, error) {
 		deletedFiles = append(deletedFiles, path)
 
 		// SAP JVM also creates .addon files that should be removed as well
-		addonPath := path[0:len(path)-len(".hprof")] + ".addon"
+		addonPath := path[0:len(path)-len(".hprof")] + ".addons"
 		addonFile, err := fs.Stat(addonPath)
 		if !os.IsNotExist(err) && addonFile.Mode().isRegular() {
 			var err = fs.Remove(addonPath)

--- a/cleanup/cleanup.go
+++ b/cleanup/cleanup.go
@@ -106,6 +106,17 @@ func CleanUp(fs afero.Fs, cfg Config) ([]string, error) {
 		}
 
 		deletedFiles = append(deletedFiles, path)
+
+		// SAP JVM also creates .addon files that should be removed as well
+		addonPath := path[0:len(path)-len(".hprof")] + ".addon"
+		addonFile, err := fs.Stat(addonPath)
+		if !os.IsNotExist(err) && addonFile.Mode().isRegular() {
+			var err = fs.Remove(addonPath)
+			if err != nil {
+				return nil, fmt.Errorf("Cannot delete heap dump addon file '"+addonPath+"': %v", err)
+			}
+			deletedFiles = append(deletedFiles, addonPath)
+		}
 	}
 
 	return deletedFiles, nil


### PR DESCRIPTION
SAP JVM creates an addon file next to the heap dump file. The addon file includes among other things the command line parameters of the process and the stack traces of the last out of memory errors as well as a class and meta space statistic.